### PR TITLE
Call withdrawals API without trailing slash

### DIFF
--- a/pysrc/mixin_bot_api.py
+++ b/pysrc/mixin_bot_api.py
@@ -438,7 +438,7 @@ class MixinBotApi:
 
         }
 
-        return await self.__genNetworkPostRequest('/withdrawals/', body)
+        return await self.__genNetworkPostRequest('/withdrawals', body)
 
     async def create_address(self, asset_id, public_key = "", label = "", account_name = "", account_tag = ""):
         """


### PR DESCRIPTION
Otherwise, will get a 301 response:

![image](https://github.com/learnforpractice/mixin-python/assets/107162109/89d9252c-f387-4706-a0c3-f6b6e679318d)
